### PR TITLE
added extras>client::display field to gotify payload to ensure markdo…

### DIFF
--- a/custom-gotify.py
+++ b/custom-gotify.py
@@ -50,6 +50,11 @@ issue_data = {
     "message": format_json_as_markdown(alert_json),
     "priority": alert_level,
     "title": agentname + " " + description,
+    "extras": {
+    "client::display": {
+        "contentType":"text/markdown"
+        }
+    }
 }
 
 # Send the request


### PR DESCRIPTION
Although the python script generates markdown code, the payload has to specify that it should be interpreted as markdown for the client to display markdown correctly.